### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+
+matrix:
+  include:
+    - node_js: "6"
+    - node_js: "7"
+
+notifications:
+  email: false


### PR DESCRIPTION
I believe a CI is required by greenkeeper to verify what gets green or not when making a PR to update the deps 👍 